### PR TITLE
Update .NET version && Propose a new OneOf implementation

### DIFF
--- a/ControlFlowBenchmarks.cs
+++ b/ControlFlowBenchmarks.cs
@@ -100,7 +100,51 @@ public class ControlFlowBenchmarks
             failure => false
         );
     }
+    
+    [Benchmark]
+    public bool ReturnTypePoly()
+    {
+        var result = DoSomethingPoly();
 
+        return result switch {
+            AReturn.AReturnValue _ => true,
+            _ => false
+        };
+    }
+    
+    [Benchmark]
+    public bool ReturnTypePolyStatic()
+    {
+        var result = DoSomethingPolyStatic();
+
+        return result switch {
+            AReturn.AReturnValue _ => true,
+            _ => false
+        };
+    }
+
+    AReturn DoSomethingPolyStatic()
+    {
+        var v = _random.Next(1);
+
+        if (v == 0)
+        {
+            return AReturn.AnError;
+        }
+        return new AReturn.AReturnValue(v);
+    }
+    
+    AReturn DoSomethingPoly()
+    {
+        var v = _random.Next(1);
+
+        if (v == 0)
+        {
+            return new AReturn.AError();
+        }
+        return new AReturn.AReturnValue(v);
+    }
+    
     int DoSomethingExceptional()
     {
         var v = _random.Next(1);
@@ -208,6 +252,14 @@ public record Failure()
 
 [GenerateOneOf]
 public partial class ReturnType : OneOfBase<int, Failure> {}
+
+public record AReturn
+{
+    public static AError AnError = new AError();
+    
+    public record AReturnValue(int Value) : AReturn;
+    public record AError : AReturn;
+}
 
 public class AnObject
 {

--- a/one-of.csproj
+++ b/one-of.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>one_of</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Hello,

I'm personally using a kind of polymorphism to mimic F# union types. It fares really well comparing with all your solutions and is even on pare with the nullable one. 

In conjunction with switch statements I'm using it seamlessly.

I Hope you find it interesting.